### PR TITLE
Fix: Skip Snyk Github Workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   snyk:
     runs-on: ubuntu-latest
-    if: github.repository != 'signalapp/Signal-Desktop'
+    if: ${{false}}
 
     steps:
       - run: lsb_release -a


### PR DESCRIPTION
# Remove Snyk Github Workflow
Due to a missing snyk token, the github workflow for snyk will always fail.
With this PR the workflow for snyk will always be skipped.