### PR TITLE
Fix/menu

### DIFF
--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -271,8 +271,6 @@
         ),
         generalHeader: i18n('general'),
         spellCheckDescription: i18n('spellCheckDescription'),
-        sendLinkPreviews: i18n('sendLinkPreviews'),
-        linkPreviewsDescription: i18n('linkPreviewsDescription'),
         privacySettings: i18n('privacySettings'),
         sendReadReceipts: i18n('sendReadReceipts'),
         udIndicators: i18n('udIndicators'),

--- a/ts/background.ts
+++ b/ts/background.ts
@@ -1475,6 +1475,20 @@ type WhatIsThis = typeof window.WhatIsThis;
     }
   });
 
+  window.Whisper.events.on('manageDevices', () => {
+    const { appView } = window.owsDesktopApp;
+    if (appView) {
+      appView.openManageDevices();
+    }
+  });
+
+  window.Whisper.events.on('addDevice', () => {
+    const { appView } = window.owsDesktopApp;
+    if (appView) {
+      appView.openAddDevice();
+    }
+  });
+
   function runStorageService() {
     window.Signal.Services.enableStorageService();
     window.textsecure.messaging.sendRequestKeySyncMessage();

--- a/ts/background.ts
+++ b/ts/background.ts
@@ -421,7 +421,19 @@ type WhatIsThis = typeof window.WhatIsThis;
       getLastSyncTime: () => window.storage.get('synced_at'),
       setLastSyncTime: (value: WhatIsThis) =>
         window.storage.put('synced_at', value),
-
+      getReadReceiptSetting: () => window.storage.get('read-receipt-setting'),
+      setReadReceiptSetting: (value: boolean) =>
+        window.storage.put('read-receipt-setting', value),
+      getUnidentifiedDeliveryIndicatorSetting: () =>
+        window.storage.get('unidentifiedDeliveryIndicators'),
+      setUnidentifiedDeliveryIndicatorSetting: (value: boolean) =>
+        window.storage.put('unidentifiedDeliveryIndicators', value),
+      getTypingIndicatorSetting: () => window.storage.get('typingIndicators'),
+      setTypingIndicatorSetting: (value: boolean) =>
+        window.storage.put('typingIndicators', value),
+      getLinkPreviewSetting: () => window.storage.get('linkPreviews'),
+      setLinkPreviewSetting: (value: boolean) =>
+        window.storage.put('linkPreviews', value),
       addDarkOverlay: () => {
         if ($('.dark-overlay').length) {
           return;


### PR DESCRIPTION
# Fix Menu&Settings
The merge broke the menu and the settings view.
The menu is fixed by adding event handlers for the according Whisper events.
In the settings view two attributes are removed and in background.ts getters and setters are installed for the custom settings.